### PR TITLE
Add Sunny AI chat assistant

### DIFF
--- a/api/chat.php
+++ b/api/chat.php
@@ -1,0 +1,134 @@
+<?php
+declare(strict_types=1);
+
+session_name('logistics_session');
+session_start();
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['error' => 'Method not allowed']);
+    exit();
+}
+
+if (!isset($_SESSION['user_id'], $_SESSION['role'])) {
+    http_response_code(401);
+    echo json_encode(['error' => 'Unauthorized']);
+    exit();
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!is_array($input) || !isset($input['message'])) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid request']);
+    exit();
+}
+
+$message = trim((string) $input['message']);
+
+if (preg_match('/\b(insert|update|delete|truncate|drop)\b/i', $message)) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Only read-only queries are allowed.']);
+    exit();
+}
+
+require_once '../config.php';
+$conn = getDBConnection();
+
+function listTables(mysqli $conn): array
+{
+    $tables = [];
+    $result = $conn->query('SHOW TABLES');
+    while ($row = $result->fetch_array()) {
+        $tables[] = $row[0];
+    }
+    return $tables;
+}
+
+function listColumns(mysqli $conn, string $table): array
+{
+    $stmt = $conn->prepare("SHOW COLUMNS FROM `{$table}`");
+    $stmt->execute();
+    $result = $stmt->get_result();
+    $columns = [];
+    while ($row = $result->fetch_assoc()) {
+        $columns[] = $row['Field'];
+    }
+    $stmt->close();
+    return $columns;
+}
+
+$schemaText = "";
+foreach (listTables($conn) as $table) {
+    $cols = listColumns($conn, $table);
+    $schemaText .= "- {$table}: " . implode(', ', $cols) . "\n";
+}
+
+$role = (string) $_SESSION['role'];
+$userId = (int) $_SESSION['user_id'];
+
+$adjustedMessage = $message;
+if ($role === 'user' && stripos($message, 'select') !== false) {
+    if (!preg_match('/where\s+[^;]*user_id/i', $message)) {
+        $adjustedMessage = rtrim($message, "; ") . " WHERE user_id = {$userId}";
+    }
+}
+
+$prompt = "You are Sunny, an AI assistant for the Solterra Logistics Portal. "
+    . "Only use read-only SQL (SELECT/SHOW). The current user role is {$role} "
+    . "with ID {$userId}. Available tables and columns:\n{$schemaText}\n"
+    . "User message: {$adjustedMessage}";
+
+$aiHost = getenv('OC_AI_HOST');
+$aiPort = getenv('OC_AI_PORT');
+$model  = getenv('OC_AI_MODEL');
+
+$payload = json_encode([
+    'model' => $model,
+    'prompt' => $prompt,
+    'stream' => true,
+]);
+
+$ch = curl_init("http://{$aiHost}:{$aiPort}/api/generate");
+curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
+curl_setopt($ch, CURLOPT_POST, true);
+curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
+
+$reply = '';
+$usageTokens = 0;
+
+curl_setopt($ch, CURLOPT_WRITEFUNCTION, function ($ch, $data) use (&$reply, &$usageTokens) {
+    static $buffer = '';
+    $buffer .= $data;
+    while (($pos = strpos($buffer, "\n")) !== false) {
+        $line = trim(substr($buffer, 0, $pos));
+        $buffer = substr($buffer, $pos + 1);
+        if ($line === '') {
+            continue;
+        }
+        $json = json_decode($line, true);
+        if (!$json) {
+            continue;
+        }
+        if (isset($json['response'])) {
+            $reply .= $json['response'];
+            echo json_encode(['token' => $json['response']]) . "\n";
+            @ob_flush();
+            flush();
+        }
+        if (!empty($json['done'])) {
+            $usageTokens = ($json['prompt_eval_count'] ?? 0) + ($json['eval_count'] ?? 0);
+        }
+    }
+    return strlen($data);
+});
+
+curl_exec($ch);
+curl_close($ch);
+
+echo json_encode([
+    'done' => true,
+    'reply' => $reply,
+    'usage_tokens' => $usageTokens,
+]) . "\n";

--- a/components/chat-widget.js
+++ b/components/chat-widget.js
@@ -1,0 +1,76 @@
+class SunnyChat {
+  constructor() {
+    this.container = document.getElementById('sunny-chat');
+    if (!this.container) return;
+    this.render();
+  }
+
+  render() {
+    this.container.innerHTML = `
+      <div class="sunny-box fixed bottom-4 right-4 w-80 bg-white shadow-lg rounded-lg flex flex-col text-sm">
+        <div class="flex items-center justify-between bg-yellow-500 text-white p-2 rounded-t-lg">
+          <span>Sunny</span>
+          <button type="button" id="sunny-close" class="font-bold">&times;</button>
+        </div>
+        <div id="sunny-messages" class="p-2 space-y-2 overflow-y-auto" style="max-height:200px"></div>
+        <form id="sunny-form" class="flex border-t p-2 gap-2">
+          <input id="sunny-input" class="flex-1 border rounded px-2" placeholder="Ask me..." />
+          <button class="bg-yellow-500 text-white px-3 rounded">Send</button>
+        </form>
+      </div>`;
+
+    this.messagesEl = this.container.querySelector('#sunny-messages');
+    this.form = this.container.querySelector('#sunny-form');
+    this.input = this.container.querySelector('#sunny-input');
+    this.container.querySelector('#sunny-close').addEventListener('click', () => {
+      this.container.querySelector('.sunny-box').classList.toggle('hidden');
+    });
+    this.form.addEventListener('submit', e => {
+      e.preventDefault();
+      this.sendMessage(this.input.value.trim());
+      this.input.value = '';
+    });
+  }
+
+  addBubble(text, from) {
+    const div = document.createElement('div');
+    div.className = from === 'user' ? 'self-end bg-blue-100 p-2 rounded' : 'bg-gray-100 p-2 rounded';
+    div.textContent = text;
+    this.messagesEl.appendChild(div);
+    this.messagesEl.scrollTop = this.messagesEl.scrollHeight;
+    return div;
+  }
+
+  async sendMessage(msg) {
+    if (!msg) return;
+    this.addBubble(msg, 'user');
+    const bubble = this.addBubble('', 'ai');
+    const response = await fetch('/Solterra-Logistics-Portal/api/chat.php', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: msg })
+    });
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      let lines = buffer.split('\n');
+      buffer = lines.pop();
+      for (const line of lines) {
+        if (!line) continue;
+        const chunk = JSON.parse(line);
+        if (chunk.token) {
+          bubble.textContent += chunk.token;
+        }
+        if (chunk.done) {
+          bubble.textContent += '\n';
+        }
+      }
+    }
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => new SunnyChat());

--- a/header.php
+++ b/header.php
@@ -314,7 +314,7 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 
     // Close dropdowns when clicking outside
-    document.addEventListener('click', function(e) {
+document.addEventListener('click', function(e) {
         if (!e.target.closest('.dropdown')) {
             document.querySelectorAll('.menu li.dropdown.open').forEach(openDropdown => {
                 openDropdown.classList.remove('open');
@@ -323,3 +323,5 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 });
 </script>
+<div id="sunny-chat"></div>
+<script src="/Solterra-Logistics-Portal/components/chat-widget.js" defer></script>

--- a/login.php
+++ b/login.php
@@ -160,5 +160,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
     <footer>
         <p>© Solterra Solutions. All Rights Reserved.</p>
     </footer>
+    <div id="sunny-chat"></div>
+    <script src="/Solterra-Logistics-Portal/components/chat-widget.js" defer></script>
 </body>
 </html>

--- a/unauthorized.php
+++ b/unauthorized.php
@@ -9,5 +9,7 @@
     <h1>Unauthorized Access</h1>
     <p>You do not have permission to view this page.</p>
     <a href="login">Return to Login</a>
+    <div id="sunny-chat"></div>
+    <script src="/Solterra-Logistics-Portal/components/chat-widget.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- implement `api/chat.php` for Ollama-backed AI assistant
- stream AI responses to browser
- add `chat-widget.js` component with minimal chat UI
- inject widget loader into portal header and login/unauthorized pages

## Testing
- `php -l api/chat.php`
- `php -l login.php unauthorized.php header.php`

------
https://chatgpt.com/codex/tasks/task_e_685808071f60832cbb86246aba5ebaa5