### PR TITLE
Add scheduling dropdown and date display

### DIFF
--- a/create_shipment.php
+++ b/create_shipment.php
@@ -215,18 +215,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['action'] ?? '') === 'ship_
             // Project delivery - offer scheduling
             $shipMessage = "{$totalDeliveries} deliveries successfully created for {$totalPallets} pallets.";
             
-            // Add scheduling links if deliveries were created for a project
+            // Provide single scheduling link for the project
             if ($destinationId > 0) {
-                $schedulingLinks = [];
-                foreach ($createdDeliveryIds as $deliveryId) {
-                    $schedulingLinks[] = "<a href='scheduling.php?project_id={$destinationId}&delivery_id={$deliveryId}' style='color: #488C9A; text-decoration: underline;'>Schedule Delivery #{$deliveryId}</a>";
-                }
-                
-                if (count($schedulingLinks) === 1) {
-                    $shipMessage .= " " . $schedulingLinks[0];
-                } else {
-                    $shipMessage .= "<br><strong>Schedule Deliveries:</strong><br>" . implode("<br>", $schedulingLinks);
-                }
+                $shipMessage .= " <a href='scheduling.php?project_id={$destinationId}' style='color: #488C9A; text-decoration: underline;'>Schedule Delivery</a>";
             }
         }
     } catch (Exception $e) {

--- a/scheduling.php
+++ b/scheduling.php
@@ -461,6 +461,25 @@ if ($action) {
         }
     }
 
+    // List available deliveries for dropdown
+    if ($action === 'list_deliveries') {
+        $stmt = $conn->prepare(
+            "SELECT id, bol_number, wattage, quantity, supplier
+             FROM deliveries
+             WHERE project_id = ? AND status_of_delivery = 'In Transit to Project'
+             ORDER BY bol_number"
+        );
+        $stmt->bind_param("i", $project_id);
+        $stmt->execute();
+        $res = $stmt->get_result();
+        $deliveries = [];
+        while ($row = $res->fetch_assoc()) {
+            $deliveries[] = $row;
+        }
+        $stmt->close();
+        json_response(['success' => true, 'deliveries' => $deliveries]);
+    }
+
     // Add appointment (linked to delivery)
     if ($action === 'add_appointment') {
         $delivery_id = isset($_POST['delivery_id']) ? intval($_POST['delivery_id']) : 0;
@@ -1806,10 +1825,20 @@ include('header.php');
                     <input type="hidden" name="csrf_token" value="<?php echo $csrf_token; ?>">
                     <input type="hidden" name="start_datetime" id="add_start_datetime">
                     <input type="hidden" name="delivery_id" id="add_delivery_id">
-                    
+
+                    <div class="form-group" id="bolSelectGroup" style="display:none;">
+                        <label for="bol_select">BOL Number</label>
+                        <select id="bol_select"></select>
+                    </div>
+
                     <div class="form-group" id="timeSelectionGroup" style="display: none;">
                         <label for="appointment_time">Select Time:</label>
                         <input type="time" id="appointment_time" name="appointment_time" value="08:00">
+                    </div>
+
+                    <div class="form-group">
+                        <label>Delivery Date &amp; Time:</label>
+                        <div id="selectedDateTimeDisplay"></div>
                     </div>
 
                     <div class="form-group" id="deliveryInfoGroup">
@@ -1861,6 +1890,11 @@ include('header.php');
                         <div class="form-group">
                             <label>BOL Number</label>
                             <input type="text" name="bol_number" id="edit_bol_number" readonly>
+                        </div>
+
+                        <div class="form-group">
+                            <label>Delivery Date &amp; Time</label>
+                            <div id="editDateTimeDisplay"></div>
                         </div>
 
                         <div class="form-group" id="deliveryInfoEditGroup" style="display: none;">
@@ -2358,37 +2392,58 @@ include('header.php');
         
         function formatDate(dateStr) {
             const date = new Date(dateStr);
-            return date.toLocaleDateString('en-US', { 
-                weekday: 'long', 
-                year: 'numeric', 
-                month: 'long', 
-                day: 'numeric' 
+            return date.toLocaleDateString('en-US', {
+                weekday: 'long',
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric'
+            });
+        }
+
+        function formatDateTime(dateStr) {
+            const date = new Date(dateStr);
+            return date.toLocaleString('en-US', {
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+                hour: '2-digit',
+                minute: '2-digit'
             });
         }
         
         function openAddModal(datetime) {
             // Check if this is coming from month view (time is just date with start time)
             const isMonthView = currentView === 'month';
-            
+
             if (isMonthView) {
                 // For month view, show time selection
                 const datePart = datetime.split(' ')[0]; // Get just the date part
                 document.getElementById('add_start_datetime').value = datePart;
                 document.getElementById('timeSelectionGroup').style.display = 'block';
+                document.getElementById('selectedDateTimeDisplay').textContent = formatDate(datePart);
+                const timeInput = document.getElementById('appointment_time');
+                timeInput.onchange = function() {
+                    const combined = datePart + ' ' + this.value;
+                    document.getElementById('selectedDateTimeDisplay').textContent = formatDateTime(combined);
+                };
             } else {
                 // For day/week view, use the exact datetime
                 document.getElementById('add_start_datetime').value = datetime;
                 document.getElementById('timeSelectionGroup').style.display = 'none';
+                document.getElementById('selectedDateTimeDisplay').textContent = formatDateTime(datetime);
             }
-            
+
             // Show/hide delivery selection based on whether we have a delivery_id
             if (deliveryId > 0) {
                 document.getElementById('add_delivery_id').value = deliveryId;
                 document.getElementById('deliveryInfoGroup').style.display = 'block';
+                document.getElementById('bolSelectGroup').style.display = 'none';
             } else {
                 document.getElementById('deliveryInfoGroup').style.display = 'none';
+                document.getElementById('bolSelectGroup').style.display = 'block';
+                loadAvailableDeliveries();
             }
-            
+
             document.getElementById('addAppointmentModal').style.display = 'flex';
         }
         
@@ -2409,6 +2464,7 @@ include('header.php');
                         document.getElementById('edit_bol_number').value = appointment.bol_number || '';
                         document.getElementById('edit_reference_numbers').value = appointment.reference_numbers || '';
                         document.getElementById('edit_description').value = appointment.description || '';
+                        document.getElementById('editDateTimeDisplay').textContent = formatDateTime(appointment.start_time);
                         
                         // Format datetime for input fields
                         if (appointment.arrival_time) {
@@ -2454,6 +2510,41 @@ include('header.php');
                 .catch(error => {
                     console.error('Error loading delivery data:', error);
                 });
+        }
+
+        function loadAvailableDeliveries() {
+            fetch(`scheduling.php?action=list_deliveries&project_id=${projectId}`)
+                .then(response => response.json())
+                .then(data => {
+                    const select = document.getElementById('bol_select');
+                    select.innerHTML = '<option value="">Select BOL</option>';
+                    if (data.success) {
+                        data.deliveries.forEach(del => {
+                            const opt = document.createElement('option');
+                            opt.value = del.id;
+                            opt.textContent = del.bol_number;
+                            opt.dataset.supplier = del.supplier;
+                            opt.dataset.wattage = del.wattage;
+                            opt.dataset.quantity = del.quantity;
+                            select.appendChild(opt);
+                        });
+                    }
+                })
+                .catch(err => console.error('Error loading deliveries', err));
+
+            document.getElementById('bol_select').addEventListener('change', function() {
+                const selected = this.options[this.selectedIndex];
+                document.getElementById('add_delivery_id').value = this.value;
+                if (this.value) {
+                    document.getElementById('deliveryBOL').textContent = selected.textContent;
+                    document.getElementById('deliverySupplier').textContent = selected.dataset.supplier || '-';
+                    document.getElementById('deliveryWattage').textContent = selected.dataset.wattage || '0';
+                    document.getElementById('deliveryQuantity').textContent = selected.dataset.quantity || '0';
+                    document.getElementById('deliveryInfoGroup').style.display = 'block';
+                } else {
+                    document.getElementById('deliveryInfoGroup').style.display = 'none';
+                }
+            });
         }
         
         function submitAppointment() {
@@ -2797,6 +2888,8 @@ include('header.php');
                         document.getElementById('edit_bol_number').value = appointment.bol_number || '';
                         document.getElementById('edit_reference_numbers').value = appointment.reference_numbers || '';
                         document.getElementById('edit_description').value = appointment.description || '';
+
+                        document.getElementById('editDateTimeDisplay').textContent = formatDateTime(appointment.start_time);
                         
                         // Show delivery information if available
                         if (appointment.supplier || appointment.delivery_quantity || appointment.wattage) {


### PR DESCRIPTION
## Summary
- simplify scheduling link to one per project
- allow scheduling form to select BOL from deliveries in transit
- show selected delivery date/time in schedule and edit modals

## Testing
- `php -l scheduling.php`
- `php -l create_shipment.php`
- `composer install --no-dev`

------
https://chatgpt.com/codex/tasks/task_e_6877f11abe50832c81cb9940860ab2c0