### PR TITLE
Fix module movement path display

### DIFF
--- a/create_shipment.php
+++ b/create_shipment.php
@@ -82,6 +82,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['action'] ?? '') === 'ship_
 
         $destinationType = $_POST['destination_type'] ?? 'project';
         $destinationId   = isset($_POST['destination_id']) ? intval($_POST['destination_id']) : 0;
+        $originType      = $_POST['origin_type'] ?? 'manufacturer';
+        $originId        = isset($_POST['origin_id']) && $_POST['origin_id'] !== '' ? intval($_POST['origin_id']) : null;
         $bolNumber       = trim($_POST['bol_number'] ?? '');
         $bolNumbers      = isset($_POST['bol_numbers']) ? json_decode($_POST['bol_numbers'], true) : [];
         $departureDate   = $_POST['departure_date'] ?? null;
@@ -110,6 +112,21 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['action'] ?? '') === 'ship_
         // Fetch supplier/vendor_name for this batch
         $vendor_name = $current_batch_vendor_name ?? 'Unknown Vendor';
 
+        // Determine supplier name based on origin
+        $supplier_name = $vendor_name;
+        if ($originType === 'warehouse' && $originId) {
+            $whStmt = $conn->prepare("SELECT name FROM warehouses WHERE id = ?");
+            if ($whStmt) {
+                $whStmt->bind_param("i", $originId);
+                $whStmt->execute();
+                $whStmt->bind_result($whName);
+                if ($whStmt->fetch()) {
+                    $supplier_name = $whName;
+                }
+                $whStmt->close();
+            }
+        }
+
         // Fetch details for selected pallets
         $placeholders = implode(',', array_fill(0, count($palletIds), '?'));
         $types        = str_repeat('i', count($palletIds));
@@ -134,20 +151,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['action'] ?? '') === 'ship_
             $palletGroups[] = $allPallets;
         }
 
-        // Prepare statements for delivery and pallet updates
-        $sqlDelivery = "";
-        $deliveryTypes = "";
-        $deliveryParams = [];
-        if ($destinationType === 'project') {
-            $sqlDelivery = "INSERT INTO deliveries (project_id, supplier, origin_type, origin_id, wattage, quantity, bol_number, anticipated_delivery_date, status_of_delivery, freight_cost, accessorial_costs, customer_cost, miles) VALUES (?, ?, 'manufacturer', NULL, ?, ?, ?, ?, 'In Transit to Project', ?, ?, ?, ?)";
-            $deliveryTypes = "ississdddd";
-        } else {
-            $sqlDelivery = "INSERT INTO deliveries (project_id, warehouse_id, supplier, origin_type, origin_id, wattage, quantity, bol_number, anticipated_delivery_date, status_of_delivery, freight_cost, accessorial_costs, customer_cost, miles) VALUES (?, ?, ?, 'manufacturer', NULL, ?, ?, ?, ?, 'In Transit to Warehouse', ?, ?, ?, ?)";
-            $deliveryTypes = "iississdddd";
-        }
-        $stmtDelivery = $conn->prepare($sqlDelivery);
-        if (!$stmtDelivery) throw new Exception("Failed to prepare delivery insert: " . $conn->error);
-
+        // Dynamic delivery insert to properly record origin details
         $stmtLink = $conn->prepare("INSERT INTO delivery_pallets (delivery_id, inventory_pallet_id) VALUES (?, ?)");
         if (!$stmtLink) throw new Exception("Failed to prepare pallet link insert: " . $conn->error);
 
@@ -158,11 +162,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['action'] ?? '') === 'ship_
         $groupIndex = 0;
         foreach ($palletGroups as $group) {
             // Determine which BOL number to use
-            $currentBolNumber = $bolNumber; // Default for single shipments
+            $currentBolNumber = $bolNumber;
             if ($shipmentMode === 'multi' && !empty($bolNumbers)) {
                 $currentBolNumber = $bolNumbers[$groupIndex] ?? $bolNumber;
             }
-            
+
             // Group by wattage for each delivery
             $groupByWattage = [];
             foreach ($group as $pallet) {
@@ -170,37 +174,109 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['action'] ?? '') === 'ship_
                 if (!isset($groupByWattage[$w])) $groupByWattage[$w] = [];
                 $groupByWattage[$w][] = $pallet;
             }
+
             foreach ($groupByWattage as $wattage => $palletsForWatt) {
                 $groupQty = array_sum(array_column($palletsForWatt, 'quantity'));
-                if ($destinationType === 'project') {
-                    $deliveryParams = [$destinationId, $vendor_name, $wattage, $groupQty, $currentBolNumber, $estArrivalDate, $freightCost, $accessorialCost, $customerCost, $miles];
-                } else {
-                    $deliveryParams = [$source_project_id_for_delivery, $destinationId, $vendor_name, $wattage, $groupQty, $currentBolNumber, $estArrivalDate, $freightCost, $accessorialCost, $customerCost, $miles];
+
+                $deliveryColumns = [
+                    'supplier',
+                    'origin_type',
+                    'origin_id',
+                    'wattage',
+                    'quantity',
+                    'bol_number'
+                ];
+                $deliveryParams = [
+                    $supplier_name,
+                    $originType,
+                    $originId,
+                    $wattage,
+                    $groupQty,
+                    $currentBolNumber
+                ];
+                $deliveryTypes = 'ssiisi';
+
+                if ($originType === 'warehouse') {
+                    $deliveryColumns[] = 'left_warehouse_date';
+                    $deliveryParams[] = $departureDate;
+                    $deliveryTypes .= 's';
                 }
+
+                $deliveryColumns[] = 'anticipated_delivery_date';
+                $deliveryParams[] = $estArrivalDate;
+                $deliveryTypes .= 's';
+
+                $statusOfDelivery = ($destinationType === 'project') ? 'In Transit to Project' : 'In Transit to Warehouse';
+                $deliveryColumns[] = 'status_of_delivery';
+                $deliveryParams[] = $statusOfDelivery;
+                $deliveryTypes .= 's';
+
+                $deliveryColumns[] = 'freight_cost';
+                $deliveryParams[] = $freightCost;
+                $deliveryTypes .= 'd';
+
+                $deliveryColumns[] = 'accessorial_costs';
+                $deliveryParams[] = $accessorialCost;
+                $deliveryTypes .= 'd';
+
+                $deliveryColumns[] = 'customer_cost';
+                $deliveryParams[] = $customerCost;
+                $deliveryTypes .= 'd';
+
+                $deliveryColumns[] = 'miles';
+                $deliveryParams[] = $miles;
+                $deliveryTypes .= 'd';
+
+                if ($destinationType === 'project') {
+                    $deliveryColumns[] = 'project_id';
+                    $deliveryParams[] = $destinationId;
+                    $deliveryTypes .= 'i';
+                    if ($originType === 'warehouse') {
+                        $deliveryColumns[] = 'warehouse_id';
+                        $deliveryParams[] = $originId;
+                        $deliveryTypes .= 'i';
+                    }
+                } else { // Destination is another warehouse
+                    $deliveryColumns[] = 'project_id';
+                    $deliveryParams[] = $source_project_id_for_delivery;
+                    $deliveryTypes .= 'i';
+
+                    $deliveryColumns[] = 'warehouse_id';
+                    $deliveryParams[] = $destinationId;
+                    $deliveryTypes .= 'i';
+                }
+
+                $placeholders = implode(',', array_fill(0, count($deliveryParams), '?'));
+                $sqlDeliveryInsert = 'INSERT INTO deliveries (' . implode(',', $deliveryColumns) . ') VALUES (' . $placeholders . ')';
+                $stmtDelivery = $conn->prepare($sqlDeliveryInsert);
+                if (!$stmtDelivery) throw new Exception('Failed to prepare delivery insert: ' . $conn->error);
+
                 $stmtDelivery->bind_param($deliveryTypes, ...$deliveryParams);
                 if (!$stmtDelivery->execute()) {
-                    throw new Exception("Failed to insert delivery for {$wattage}W: " . $stmtDelivery->error);
+                    throw new Exception('Failed to insert delivery for ' . $wattage . 'W: ' . $stmtDelivery->error);
                 }
+
                 $deliveryId = $conn->insert_id;
                 $createdDeliveryIds[] = $deliveryId;
+
                 foreach ($palletsForWatt as $pallet) {
-                    $stmtLink->bind_param("ii", $deliveryId, $pallet['id']);
+                    $stmtLink->bind_param('ii', $deliveryId, $pallet['id']);
                     if (!$stmtLink->execute()) {
-                        throw new Exception("Failed to link pallet ID {$pallet['id']} to delivery {$deliveryId}: " . $stmtLink->error);
+                        throw new Exception('Failed to link pallet ID ' . $pallet['id'] . ' to delivery ' . $deliveryId . ': ' . $stmtLink->error);
                     }
-                    // Update pallet status/location
+
                     $status = ($destinationType === 'project') ? 'In Transit to Project' : 'In Transit to Warehouse';
                     $projectId = ($destinationType === 'project') ? $destinationId : null;
                     $warehouseId = ($destinationType === 'warehouse') ? $destinationId : null;
-                    $stmtUp->bind_param("siisi", $status, $projectId, $warehouseId, $estArrivalDate, $pallet['id']);
+                    $stmtUp->bind_param('siisi', $status, $projectId, $warehouseId, $estArrivalDate, $pallet['id']);
                     if (!$stmtUp->execute()) {
-                        throw new Exception("Failed to update pallet ID {$pallet['id']}: " . $stmtUp->error);
+                        throw new Exception('Failed to update pallet ID ' . $pallet['id'] . ': ' . $stmtUp->error);
                     }
                 }
             }
-            $groupIndex++; // Move to next BOL number for next truck
+            $groupIndex++;
         }
-        $stmtDelivery->close();
+
         $stmtLink->close();
         $stmtUp->close();
         $conn->commit();

--- a/module_movements.php
+++ b/module_movements.php
@@ -183,6 +183,14 @@ try {
                 COALESCE(w.city, '') as delivery_wh_city,
                 COALESCE(w.state, '') as delivery_wh_state,
                 COALESCE(w.zip_code, '') as delivery_wh_zip,
+
+                -- Origin warehouse info (where delivery originated if from a warehouse)
+                w_origin.id as origin_warehouse_id,
+                COALESCE(w_origin.name, '') as origin_warehouse_name,
+                COALESCE(w_origin.street_address, '') as origin_wh_street,
+                COALESCE(w_origin.city, '') as origin_wh_city,
+                COALESCE(w_origin.state, '') as origin_wh_state,
+                COALESCE(w_origin.zip_code, '') as origin_wh_zip,
                 
                 -- Project info
                 p.project_name,
@@ -216,9 +224,15 @@ try {
                 )
             )
             
-            -- LEFT JOIN to deliveries
-            LEFT JOIN delivery_pallets dp ON ip.id = dp.inventory_pallet_id
-            LEFT JOIN deliveries d ON dp.delivery_id = d.id
+            -- Join to the most recent delivery for each pallet to avoid
+            -- duplicate rows when pallets have multiple deliveries
+            LEFT JOIN (
+                SELECT dp.inventory_pallet_id, MAX(dp.delivery_id) AS latest_delivery_id
+                FROM delivery_pallets dp
+                JOIN deliveries d2 ON dp.delivery_id = d2.id
+                GROUP BY dp.inventory_pallet_id
+            ) dp_latest ON dp_latest.inventory_pallet_id = ip.id
+            LEFT JOIN deliveries d ON dp_latest.latest_delivery_id = d.id
             
             -- Link to project
             INNER JOIN projects p ON (
@@ -231,6 +245,7 @@ try {
             -- Link to warehouses
             LEFT JOIN warehouses w ON d.warehouse_id = w.id
             LEFT JOIN warehouses w2 ON ip.current_warehouse_id = w2.id
+            LEFT JOIN warehouses w_origin ON (d.origin_type = 'warehouse' AND d.origin_id = w_origin.id)
             
             WHERE p.id = ?
             GROUP BY 
@@ -238,6 +253,7 @@ try {
                 mfg.name, mfg.street_address, mfg.city, mfg.state, mfg.zip_code,
                 w2.id, w2.name, w2.street_address, w2.city, w2.state, w2.zip_code,
                 w.id, w.name, w.street_address, w.city, w.state, w.zip_code,
+                w_origin.id, w_origin.name, w_origin.street_address, w_origin.city, w_origin.state, w_origin.zip_code,
                 p.project_name, p.street_address, p.city, p.state, p.zip_code,
                 d.origin_type, d.origin_id
             ORDER BY ip.status ASC, m.vendor_name ASC
@@ -968,6 +984,22 @@ function processMovementData() {
             location.total_modules += movement.total_quantity;
         }
 
+        // Add origin warehouse location even if no pallets currently there
+        if (movement.origin_type === 'warehouse' && movement.origin_warehouse_id && movement.origin_warehouse_name) {
+            const whOrigKey = 'wh_' + movement.origin_warehouse_id;
+            if (!locations.has(whOrigKey)) {
+                locations.set(whOrigKey, {
+                    type: 'warehouse',
+                    name: movement.origin_warehouse_name,
+                    address: buildAddress(movement.origin_wh_street, movement.origin_wh_city, movement.origin_wh_state, movement.origin_wh_zip),
+                    pallets: [],
+                    total_pallets: 0,
+                    total_modules: 0,
+                    marker: null
+                });
+            }
+        }
+
         // Add project location with pallets DELIVERED to project
         if (movement.status === 'Delivered to Project') {
             const projectKey = 'proj_' + projectData.id;
@@ -1309,8 +1341,14 @@ function createRouteLines(locations) {
         } else if (movement.delivery_warehouse_id && movement.delivery_warehouse_name) {
             warehouseKey = 'wh_' + movement.delivery_warehouse_id;
         }
+
+        // Origin warehouse for deliveries leaving a warehouse
+        let originWarehouseKey = null;
+        if (movement.origin_type === 'warehouse' && movement.origin_warehouse_id && movement.origin_warehouse_name) {
+            originWarehouseKey = 'wh_' + movement.origin_warehouse_id;
+        }
         
-        // Create manufacturer → warehouse route (for aggregated groups that are currently in warehouse or were delivered to project via warehouse)
+        // Create manufacturer → warehouse route (for pallets that either reside in a warehouse or were delivered to project via that warehouse)
         if (warehouseKey && (movement.status === 'In Warehouse' || movement.status === 'Delivered to Project')) {
             const route1Key = `${manufacturerKey}_to_${warehouseKey}`;
             if (!routes.has(route1Key)) {
@@ -1329,13 +1367,34 @@ function createRouteLines(locations) {
             route.modules += parseInt(movement.total_quantity);
             route.pallet_count += parseInt(movement.pallet_count);
         }
+
+        // Create manufacturer → origin warehouse route for pallets delivered to project (to preserve historical path)
+        if (!warehouseKey && originWarehouseKey && movement.status === 'Delivered to Project') {
+            const routeOrigKey = `${manufacturerKey}_to_${originWarehouseKey}`;
+            if (!routes.has(routeOrigKey)) {
+                routes.set(routeOrigKey, {
+                    from: manufacturerKey,
+                    to: originWarehouseKey,
+                    pallets: [],
+                    modules: 0,
+                    pallet_count: 0,
+                    color: '#488C9A',
+                    type: 'manufacturer_to_warehouse'
+                });
+            }
+            const route = routes.get(routeOrigKey);
+            route.pallets.push(movement);
+            route.modules += parseInt(movement.total_quantity);
+            route.pallet_count += parseInt(movement.pallet_count);
+        }
         
         // Create warehouse → project route (for aggregated groups delivered to project)
-        if (warehouseKey && movement.status === 'Delivered to Project') {
-            const route2Key = `${warehouseKey}_to_${projectKey}`;
+        if ((warehouseKey || originWarehouseKey) && movement.status === 'Delivered to Project') {
+            const whKeyForRoute = warehouseKey || originWarehouseKey;
+            const route2Key = `${whKeyForRoute}_to_${projectKey}`;
             if (!routes.has(route2Key)) {
                 routes.set(route2Key, {
-                    from: warehouseKey,
+                    from: whKeyForRoute,
                     to: projectKey,
                     pallets: [],
                     modules: 0,


### PR DESCRIPTION
## Summary
- add origin warehouse data to aggregated movement query
- display markers for warehouses that only appear as origins
- draw routes using origin warehouse info so historical paths remain visible
- fix delivery join to use each pallet's latest shipment
- record warehouse origin data in create_shipment

## Testing
- `composer install`
- `php -l module_movements.php`
- `php -l create_shipment.php`


------
https://chatgpt.com/codex/tasks/task_e_6879066cf008832c9daec82205589a81