### PR TITLE
Fix warehousing links when no pallets remain

### DIFF
--- a/project_overview.php
+++ b/project_overview.php
@@ -727,28 +727,33 @@ $stmt_warehouses = $conn->prepare("
     LEFT JOIN inventory_pallets ip ON w.id = ip.current_warehouse_id 
         AND ip.status = 'In Warehouse' 
         AND (ip.assigned_project_id = ? OR ip.current_project_id = ?)
-    LEFT JOIN deliveries d_transit ON w.id = d_transit.warehouse_id 
-        AND d_transit.project_id = ? 
-        AND d_transit.status_of_delivery LIKE 'In Transit%' 
+    LEFT JOIN deliveries d_transit ON w.id = d_transit.warehouse_id
+        AND d_transit.project_id = ?
+        AND d_transit.status_of_delivery LIKE 'In Transit%'
         AND d_transit.warehouse_arrival_date IS NULL
-    WHERE 
+    WHERE
         EXISTS (
             SELECT 1 FROM inventory_pallets ip_check
-            WHERE ip_check.current_warehouse_id = w.id 
+            WHERE ip_check.current_warehouse_id = w.id
                 AND ip_check.status = 'In Warehouse'
                 AND (ip_check.assigned_project_id = ? OR ip_check.current_project_id = ?)
-        ) 
+        )
         OR EXISTS (
             SELECT 1 FROM deliveries d_check
-            WHERE d_check.warehouse_id = w.id 
-                AND d_check.project_id = ? 
+            WHERE d_check.warehouse_id = w.id
+                AND d_check.project_id = ?
                 AND d_check.status_of_delivery LIKE 'In Transit%'
                 AND d_check.warehouse_arrival_date IS NULL
+        )
+        OR EXISTS (
+            SELECT 1 FROM deliveries d_hist
+            WHERE d_hist.warehouse_id = w.id
+                AND d_hist.project_id = ?
         )
     GROUP BY w.id, w.name, w.address, w.image_url
     ORDER BY w.name ASC
 ");
-$stmt_warehouses->bind_param("iiiiii", $project_id, $project_id, $project_id, $project_id, $project_id, $project_id);
+$stmt_warehouses->bind_param("iiiiiii", $project_id, $project_id, $project_id, $project_id, $project_id, $project_id, $project_id);
 $stmt_warehouses->execute();
 $result_warehouses = $stmt_warehouses->get_result();
 while ($wh = $result_warehouses->fetch_assoc()) {

--- a/warehouse_info.php
+++ b/warehouse_info.php
@@ -160,26 +160,31 @@ try {
                 WHERE ip_inner.assigned_project_id = ? /* Ensure pallets in transit also belong to the project */
                 GROUP BY dp.delivery_id
             ) d_pal ON d_transit.id = d_pal.delivery_id
-            WHERE 
+            WHERE
                 EXISTS (
                     SELECT 1 FROM inventory_pallets ip_check_stored
                     WHERE ip_check_stored.assigned_project_id = ? AND ip_check_stored.current_warehouse_id = wh.id AND ip_check_stored.status = 'In Warehouse'
-                ) 
+                )
                 OR EXISTS (
                     SELECT 1 FROM deliveries d_check_transit
                     JOIN delivery_pallets dp_check_transit ON d_check_transit.id = dp_check_transit.delivery_id
                     JOIN inventory_pallets ip_check_d_transit ON dp_check_transit.inventory_pallet_id = ip_check_d_transit.id
-                    WHERE ip_check_d_transit.assigned_project_id = ? 
-                      AND d_check_transit.warehouse_id = wh.id 
+                    WHERE ip_check_d_transit.assigned_project_id = ?
+                      AND d_check_transit.warehouse_id = wh.id
                       AND d_check_transit.status_of_delivery LIKE 'In Transit%'
                       AND d_check_transit.warehouse_arrival_date IS NULL
+                )
+                OR EXISTS (
+                    SELECT 1 FROM deliveries d_hist
+                    WHERE d_hist.warehouse_id = wh.id
+                      AND d_hist.project_id = ?
                 )
             GROUP BY wh.id, wh.name, wh.address, wh.image_url
             ORDER BY wh.name ASC
         ";
         $stmtDistinctWH = $conn->prepare($sqlDistinctWH);
         if (!$stmtDistinctWH) throw new Exception("Prepare distinct warehouses failed: " . $conn->error);
-        $stmtDistinctWH->bind_param("iiiii", $project_id, $project_id, $project_id, $project_id, $project_id);
+        $stmtDistinctWH->bind_param("iiiiii", $project_id, $project_id, $project_id, $project_id, $project_id, $project_id);
         $stmtDistinctWH->execute();
         $resultDistinctWH = $stmtDistinctWH->get_result();
 


### PR DESCRIPTION
## Summary
- expand warehousing queries to include historical warehouse usage
- allow warehouse pages to load even when no pallets are currently stored

## Testing
- `php -l project_overview.php`
- `php -l warehouse_info.php`


------
https://chatgpt.com/codex/tasks/task_e_687925845a10832cbf230c1d679ff122